### PR TITLE
Add: jira formatting function

### DIFF
--- a/src/automation_start.py
+++ b/src/automation_start.py
@@ -29,3 +29,7 @@ session.headers.update(
         "Content-Type": "application/json"
     }
 )
+
+# Format the start/end dates of generated sprints.
+def format_jira_date(date) -> str:
+    return date.strftime("%Y-%m-%dT%H:%M:%S.000+0000")


### PR DESCRIPTION
Added a function to format start/end dates of sprints as required by the Jira REST API.